### PR TITLE
fix(train model action): Commit and push model comparison only if activated

### DIFF
--- a/.github/workflows/train-model.yaml
+++ b/.github/workflows/train-model.yaml
@@ -35,7 +35,7 @@ on:
           - 'false'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.commit_to_branch == 'true' && 'concurrent' || github.run_id }}
   cancel-in-progress: false
 
 permissions:
@@ -207,7 +207,8 @@ jobs:
         git pull --rebase
         git push
 
-    - name: Trigger compare-models workflow on current branch
+    - name: Trigger compare-models workflow on current branch (if enabled)
+      if: ${{ github.event.inputs.commit_to_branch == 'true' && github.ref != 'refs/heads/main' }}
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
- Commit and push model comparison images and overview to branch only if activated
- Allow concurrent trainings when not commiting results to branch